### PR TITLE
Update config.lua

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -8,18 +8,25 @@ cfg.printidentifiers = true                 -- true para mostrar os identificado
 cfg.vipmenu = {
     Enable = true,
     PaycheckInterval = 30,
-    CashType = 'bank', -- money, bank, crypto
+    CashType = 'bank',
     CoinType = "R$",
     Roles = {
         nenhum = {
             label = "Sem vip",
             payment = 0,
-            inventory = 100, -- 100 KG
+            inventory = 100,
         },
         tier1 = {
             label = "Tier 1",
             payment = 5000,
-            inventory = 200 , -- 200 KG
+            inventory = 200,
+            items = { { name = "burger", count = 2 }, { name = "water", count = 1 } }
+        },
+        tier2 = {
+            label = "Tier 2",
+            payment = 10000,
+            inventory = 300,
+            items = { { name = "soda", count = 3 }, { name = "sandwich", count = 2 } }
         }
     }
 }


### PR DESCRIPTION
você só precisa modificar o arquivo config.lua, na parte do bloco cfg.vipmenu.Roles, adicionando ou alterando a chave items para cada tier de VIP que desejar. Exemplo prático:
No seu config.lua, localize algo assim:
Apply to config.lua
name: nome do item (deve existir no seu inventário). count: quantidade (opcional, padrão é 1).
Se não quiser que um tier receba itens, basta não colocar a chave items ou deixar como {}. Resumindo:
Basta adicionar ou editar a linha items = { ... } dentro de cada tier de VIP em cfg.vipmenu.Roles no seu config.lua. Se quiser um exemplo para um item específico, só pedir!