### PR TITLE
Update vip.lua

### DIFF
--- a/modules/mri/server-side/ox_lib-modules/vip.lua
+++ b/modules/mri/server-side/ox_lib-modules/vip.lua
@@ -92,6 +92,10 @@ local function executeVip(source, args)
         lib.addPrincipal(args.id, args.tier)
         player.Functions.SetMetaData('vip', args.tier)
         sendNotification(args.id, "success", string.format("Recebeu o vip: %s", args.tier))
+        local items = cfg.vipmenu.Roles[args.tier].items or {}
+        for _, item in ipairs(items) do
+            exports.ox_inventory:AddItem(args.id, item.name, item.count or 1)
+        end
     elseif args.tipo == 'rem' and player.PlayerData.metadata['vip'] then
         lib.removePrincipal(args.id, player.PlayerData.metadata['vip'])
         player.Functions.SetMetaData('vip', nil)
@@ -160,6 +164,10 @@ RegisterNetEvent('mri_Qbox:server:manageVip', function(data)
             if targetSource > 0 then
                 lib.addPrincipal(targetSource, data.role)
                 targetPlayer.Functions.SetMetaData('vip', data.role)
+                local items = cfg.vipmenu.Roles[data.role].items or {}
+                for _, item in ipairs(items) do
+                    exports.ox_inventory:AddItem(targetSource, item.name, item.count or 1)
+                end
             end
         end
         exports.qbx_core:SaveOffline(player.PlayerData)


### PR DESCRIPTION
Quando um VIP é concedido (add), o script busca em cfg.vipmenu.Roles[tier].items a lista de itens para aquele tier. Para cada item listado, ele executa:
exports.ox_inventory:AddItem(playerId, item.name, item.count or 1) Isso vale tanto para jogadores online quanto offline. Como configurar os itens de cada VIP
No seu config.lua, basta adicionar ou editar a chave items dentro de cada tier de VIP, por exemplo: config.lua/ tier1 = {
            label = "Tier 1",
            payment = 5000,
            inventory = 200 , -- 200 KG
           items = { { name = "burger", count = 2 }, { name = "water", count = 1 } }
        }
Apply to vip.lua
name: nome do item no inventário.
count: quantidade (opcional, padrão 1).
Resumo
Para cada tier de VIP, defina a lista de itens em items. Ao dar VIP, o jogador recebe automaticamente os itens definidos.