### PR TITLE
fix(waterCooler): contar bebidas por jogador e limpar estado no drop

### DIFF
--- a/modules/waterCooler/server/server.lua
+++ b/modules/waterCooler/server/server.lua
@@ -48,26 +48,25 @@ end
 -- Function to handle excessive drinking
 local function handleExcessiveDrinking(src)
     local currentTime = os.time()
-    if not Players[src] then
+    local playerData = Players[src]
+
+    if not playerData or currentTime - playerData.lastDrinkTime > 60 then
         Players[src] = { count = 1, lastDrinkTime = currentTime }
     else
-        Players[src].count = Players[src].count + 1
-        Players[src].lastDrinkTime = currentTime
+        playerData.count = playerData.count + 1
+        playerData.lastDrinkTime = currentTime
     end
 
-    local drinksInPastMinute = 0
-    for _, playerData in pairs(Players) do
-        if currentTime - playerData.lastDrinkTime <= 60 then
-            drinksInPastMinute = drinksInPastMinute + playerData.count
-        end
-    end
-
-    if drinksInPastMinute > excessive_drink then
+    if Players[src].count > excessive_drink then
         KillPlayer(src)
     else
         notify(src, "Você está bebendo água demais!", 'error')
     end
 end
+
+AddEventHandler('playerDropped', function()
+    Players[source] = nil
+end)
 
 local function updateClientHUD(src, hunger, thirst)
     TriggerClientEvent('hud:client:UpdateNeeds', src, hunger, thirst)


### PR DESCRIPTION
## Problema

Em `modules/waterCooler/server/server.lua`, a função `handleExcessiveDrinking` somava o `count` de **todos os jogadores conectados** dentro da janela de 60s antes de comparar com `excessive_drink`. Consequência: qualquer jogador que tentasse beber com sede 100 podia receber a notificação "Você está bebendo água demais!" (e, com o `KillPlayer` implementado, ser punido) apenas porque outros jogadores haviam bebido recentemente.

Bugs secundários no mesmo bloco:

- `Players[src]` nunca era limpo no disconnect — pequeno acúmulo de estado e risco de "vazar" contagem antiga para um novo jogador quando o `src` é reciclado.
- O `count` por jogador nunca era resetado: bastava beber dentro da janela móvel para o número subir indefinidamente, contrariando a intenção de "bebidas no último minuto".

## Mudança

- `handleExcessiveDrinking` passa a comparar apenas `Players[src].count` (por jogador, sem somar a tabela inteira).
- Quando o gap desde a última bebida ultrapassa 60s, a entrada é reiniciada (`count = 1`), implementando de fato a janela móvel sugerida pelo código original.
- Adicionado `AddEventHandler('playerDropped', ...)` para limpar `Players[source]` ao desconectar.

Diff: -11 / +10 linhas em um único arquivo.

## Compatibilidade

Comportamento externo preservado: `notify` e `KillPlayer` continuam sendo chamados sob o mesmo critério (`excessive_drink`), agora aplicado corretamente por jogador. Nenhuma alteração em config, eventos ou exports.

## Como testar

1. Suba a sede de dois jogadores ao máximo (100).
2. Cada um tenta beber: cada jogador deve precisar de mais de `cfg.excessiveDrinkCount` (default 3) tentativas próprias para atingir o caminho do `KillPlayer`. Antes do fix, bastava o total entre jogadores ultrapassar o limite.
3. Aguarde >60s sem beber e tente de novo: o contador do jogador deve voltar a 1.
4. Desconecte e reconecte: `Players[src]` é zerado.